### PR TITLE
프린터: O(N) 풀이

### DIFF
--- a/heoh/programmers-42587-2.java
+++ b/heoh/programmers-42587-2.java
@@ -1,0 +1,129 @@
+import java.util.*;
+
+
+class Solution {
+    public int solution(int[] priorities, int location) {
+        FastPrinter printer = new FastPrinter();
+
+        for (int priority : priorities)
+            printer.addDocument(priority);
+
+        return printer.printFor(printer.getDocument(location));
+    }
+}
+
+
+class FastPrinter {
+    public static final int MIN_PRIORITY = 1;
+    public static final int MAX_PRIORITY = 9;
+
+    private final List<Document> documents;
+    private final Map<Integer, List<Document>> docsByPriority;
+    private int cursor;
+
+    public FastPrinter() {
+        docsByPriority = initializePriorityDocumentPool();
+        documents = new ArrayList<>();
+        cursor = 0;
+    }
+
+    private Map<Integer, List<Document>> initializePriorityDocumentPool() {
+        Map<Integer, List<Document>> pool = new HashMap<>();
+        for (int p = MIN_PRIORITY; p <= MAX_PRIORITY; p++)
+            pool.put(p, new ArrayList<>());
+        return pool;
+    }
+
+    public int printFor(Document end) {
+        int nPrintedDocs = 0;
+
+        for (int p = MAX_PRIORITY; p > end.priority; p--)
+            nPrintedDocs += printAllDocumentsInPriority(p);
+
+        nPrintedDocs += printForInPriority(end.priority, end);
+
+        return nPrintedDocs;
+    }
+
+    private int printAllDocumentsInPriority(int priority) {
+        List<Document> pool = docsByPriority.get(priority);
+        int nPrintedDocs = pool.size();
+
+        if (pool.isEmpty())
+            return nPrintedDocs;
+
+        Document firstDoc = findNextDocumentInPriority(priority);
+        Document lastDoc = getPrevDocumentInPriority(priority, firstDoc);
+
+        cursor = lastDoc.index;
+
+        return nPrintedDocs;
+    }
+
+    private int printForInPriority(int priority, Document lastDoc) {
+        List<Document> pool = docsByPriority.get(priority);
+        Document firstDoc = findNextDocumentInPriority(priority);
+
+        int nPrintedDocs;
+        if (firstDoc.poolIndex <= lastDoc.poolIndex)
+            nPrintedDocs = lastDoc.poolIndex - firstDoc.poolIndex + 1;
+        else
+            nPrintedDocs = (pool.size() + lastDoc.poolIndex) - firstDoc.poolIndex + 1;
+
+        cursor = lastDoc.index;
+
+        return nPrintedDocs;
+    }
+
+    private Document findNextDocumentInPriority(int priority) {
+        List<Document> pool = docsByPriority.get(priority);
+        int nextPoolIndex = binarySearchGreaterThanOrEqual(pool, 0, pool.size(), cursor);
+        if (nextPoolIndex >= pool.size())
+            nextPoolIndex = 0;
+        return pool.get(nextPoolIndex);
+    }
+
+    private int binarySearchGreaterThanOrEqual(List<Document> pool, int low, int high, int keyIndex) {
+        while (low < high) {
+            int mid = (low + high) / 2;
+            if (pool.get(mid).index < keyIndex)
+                low = mid + 1;
+            else
+                high = mid;
+        }
+        return high;
+    }
+
+    private Document getPrevDocumentInPriority(int priority, Document firstDoc) {
+        List<Document> pool = docsByPriority.get(priority);
+        int prevIndex = firstDoc.poolIndex - 1;
+        if (prevIndex < 0)
+            prevIndex += pool.size();
+        return pool.get(prevIndex);
+    }
+
+    public void addDocument(int priority) {
+        List<Document> pool = docsByPriority.get(priority);
+
+        Document doc = new Document(priority, documents.size(), pool.size());
+        documents.add(doc);
+        pool.add(doc);
+    }
+
+    public Document getDocument(int location) {
+        return documents.get(location);
+    }
+}
+
+
+class Document {
+    public int priority;
+    public int index;
+    public int poolIndex;
+
+    public Document(int priority, int index, int poolIndex) {
+        this.priority = priority;
+        this.index = index;
+        this.poolIndex = poolIndex;
+    }
+}


### PR DESCRIPTION
기존 방법(#11): 인쇄 큐의 문서들을 단일 큐로 관리하고, 직접 시뮬레이션

개선된 방법:
- 인쇄 큐를 우선순위에 따라 나눔. 우선순위는 1~9까지 총 9개의 큐로 나눔
  - 우선순위의 범위가 좁기 때문에 효율적임
- 항상 우선순위가 높은 것이 먼저 출력되므로, 우선순위가 높은 인쇄 큐부터 처리함
- 같은 우선순위의 문서들 중에서는 마지막에 출력된 문서 위치에서 시작해서 오른쪽 방향으로 순차적으로 출력될 것이 보장됨 (리스트의 끝에 도달하면 다시 0으로. 환형 큐 모양)
- 각 우선순위마다 처음 출력될 문서와 마지막에 출력할 문서의 위치를 빠르게 구하고, 마지막에 출력될 문서위치로 커서를 옮김
  - 전부 출력하는 우선순위에서는 처음 출력될 문서를 찾고, 마지막에 출력될 문서는 처음 출력될 문서의 바로 왼쪽에 존재함
  - 요청한 문서와 같은 우선순위에서는 `(요청한 문서의 위치) - (처음 출력될 문서의 위치)`가 해당 큐에서 출력될 양임 (환형으로 계산)

시간 복잡도:
- O(N) + 9 * O(logN) = O(N)
  - 주어진 priorites 배열 읽는 시간: O(N)
  - 9개의 우선순위 문서 큐를 이진 탐색으로 처리하는 시간: 9 * O(logN)