### PR TITLE
가장 먼 노드

### DIFF
--- a/heoh/programmers-49189.java
+++ b/heoh/programmers-49189.java
@@ -1,0 +1,70 @@
+import java.util.*;
+
+class Solution {
+    public int solution(int n, int[][] edge) {
+        Graph g = buildGraph(n, edge);
+        Map<Integer, Integer> counts = countVerticesByDistance(g, 1);
+        int maxDist = Collections.max(counts.keySet());
+        int answer = counts.get(maxDist);
+        return answer;
+    }
+
+    Graph buildGraph(int n, int[][] edge) {
+        Graph g = new Graph(n);
+        for (int[] e : edge) {
+            g.addEdge(e[0], e[1]);
+        }
+        return g;
+    }
+
+    Map<Integer, Integer> countVerticesByDistance(Graph g, int startVertex) {
+        Map<Integer, Integer> counter = new HashMap<>();
+
+        Queue<List<Integer>> q = new LinkedList<>();
+        boolean[] visited = new boolean[g.size + 1];
+
+        List<Integer> firstState = List.of(0, startVertex);
+        q.add(firstState);
+        visited[startVertex] = true;
+
+        while (!q.isEmpty()) {
+            List<Integer> state = q.poll();
+            int t = state.get(0);
+            int currVertex = state.get(1);
+
+            if (!counter.containsKey(t))
+                counter.put(t, 0);
+            counter.put(t, counter.get(t) + 1);
+
+            for (int nextVertex : g.edges.get(currVertex)) {
+                if (visited[nextVertex])
+                    continue;
+
+                List<Integer> nextState = List.of(t + 1, nextVertex);
+                q.add(nextState);
+                visited[nextVertex] = true;
+            }
+        }
+
+        return counter;
+    }
+}
+
+
+class Graph {
+    Map<Integer, List<Integer>> edges;
+    int size;
+
+    public Graph(int nVertices) {
+        size = nVertices;
+        edges = new HashMap<>();
+        for (int v = 1; v <= nVertices; v++) {
+            edges.put(v, new ArrayList<>());
+        }
+    }
+
+    public void addEdge(int vertexA, int vertexB) {
+        edges.get(vertexA).add(vertexB);
+        edges.get(vertexB).add(vertexA);
+    }
+}


### PR DESCRIPTION
```
정확성  테스트
테스트 1 〉	통과 (0.43ms, 75.6MB)
테스트 2 〉	통과 (0.45ms, 71.9MB)
테스트 3 〉	통과 (0.54ms, 72MB)
테스트 4 〉	통과 (1.20ms, 78.1MB)
테스트 5 〉	통과 (4.60ms, 79.8MB)
테스트 6 〉	통과 (7.76ms, 84.8MB)
테스트 7 〉	통과 (30.63ms, 103MB)
테스트 8 〉	통과 (43.93ms, 107MB)
테스트 9 〉	통과 (49.29ms, 117MB)
채점 결과
정확성: 100.0
합계: 100.0 / 100.0
```